### PR TITLE
Fix bug when `this` is not `window`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-module.exports = function(element, fn) {
+var exports = function(element, fn) {
   var window = this;
   var document = window.document;
 
@@ -68,3 +68,5 @@ module.exports = function(element, fn) {
   }
   element.__resizeListeners__.push(fn);
 };
+
+module.exports = (typeof window === "undefined") ? exports : exports.bind(window);


### PR DESCRIPTION
In my usecase I have something like following:

``` javascript
window.npm = {};
window.npm.element_resize_event = require('element-resize-event');
```

which is later processed with browserify and used from ClojureScript code as `js/npm.element_resize_event`. Problem is that in this case `this` turns out to be `window.npm`, not `window`. This patch fixes this problem.
