### PR TITLE
Handles case where request frame is not cancelled when DOM element is removed

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,9 +38,11 @@ var exports = function exports(element, fn) {
     }
     win.__resizeRAF__ = requestFrame(function () {
       var trigger = win.__resizeTrigger__
-      trigger.__resizeListeners__.forEach(function (fn) {
-        fn.call(trigger, e)
-      })
+      if(trigger !== undefined) {
+        trigger.__resizeListeners__.forEach(function (fn) {
+          fn.call(trigger, e)
+        })
+      }
     })
   }
 


### PR DESCRIPTION
I was noticing intermittent errors while running tests using Karma and PhantomJS for a project that uses this library.

I tracked down the cause of the error to the fact that sometimes, when the callback passed to requestFrame is actually executed, `win.__resizeTrigger__` was `undefined`.

This may be caused by the element having been removed from the DOM but the frame request is not cancelled.

I put in a not undefined check for the trigger which has resolved the issue.
