### PR TITLE
Add unbind method for removing the listener.

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,4 +76,17 @@ var exports = function exports(element, fn) {
   element.__resizeListeners__.push(fn)
 }
 
+exports.unbind = function(element, fn){
+  var attachEvent = document.attachEvent;
+  element.__resizeListeners__.splice(element.__resizeListeners__.indexOf(fn), 1);
+  if (!element.__resizeListeners__.length) {
+    if (attachEvent) {
+      element.detachEvent('onresize', resizeListener);
+    } else {
+      element.__resizeTrigger__.contentDocument.defaultView.removeEventListener('resize', resizeListener);
+      element.__resizeTrigger__ = !element.removeChild(element.__resizeTrigger__);
+    }
+  }
+}
+
 module.exports = (typeof window === 'undefined') ? exports : exports.bind(window)


### PR DESCRIPTION
For issue #2 . Added an unbind method to the exported api (pulled the code from the same blog post as the original method).

It might be better to export 2 distinct bind/unbind methods instead of hanging unbind off of the 'default' export. It would require a version bump, but would be an easy change to make.
