### PR TITLE
Unbind undef on exports

### DIFF
--- a/example/bundle.js
+++ b/example/bundle.js
@@ -94,4 +94,21 @@ var exports = function exports(element, fn) {
 
 module.exports = (typeof window === 'undefined') ? exports : exports.bind(window)
 
+module.exports.unbind = function(element, fn){
+  var attachEvent = document.attachEvent
+  if (fn) {
+    element.__resizeListeners__.splice(element.__resizeListeners__.indexOf(fn), 1)
+  } else {
+    element.__resizeListeners__ = []
+  }
+  if (!element.__resizeListeners__.length) {
+    if (attachEvent) {
+      element.detachEvent('onresize', resizeListener)
+    } else {
+      element.__resizeTrigger__.contentDocument.defaultView.removeEventListener('resize', resizeListener)
+      element.__resizeTrigger__ = !element.removeChild(element.__resizeTrigger__)
+    }
+  }
+}
+
 },{}]},{},[1]);

--- a/index.js
+++ b/index.js
@@ -1,47 +1,46 @@
+var requestFrame = (function () {
+  var raf = window.requestAnimationFrame ||
+    window.mozRequestAnimationFrame ||
+      window.webkitRequestAnimationFrame ||
+        function fallbackRAF(func) {
+          return window.setTimeout(func, 20)
+        }
+  return function requestFrameFunction(func) {
+    return raf(func)
+  }
+})()
+
+var cancelFrame = (function () {
+  var cancel = window.cancelAnimationFrame ||
+    window.mozCancelAnimationFrame ||
+      window.webkitCancelAnimationFrame ||
+        window.clearTimeout
+  return function cancelFrameFunction(id) {
+    return cancel(id)
+  }
+})()
+
+function resizeListener(e) {
+  var win = e.target || e.srcElement
+  if (win.__resizeRAF__) {
+    cancelFrame(win.__resizeRAF__)
+  }
+  win.__resizeRAF__ = requestFrame(function () {
+    var trigger = win.__resizeTrigger__
+    trigger.__resizeListeners__.forEach(function (fn) {
+      fn.call(trigger, e)
+    })
+  })
+}
+
 var exports = function exports(element, fn) {
   var window = this
   var document = window.document
   var isIE
-  var requestFrame
 
   var attachEvent = document.attachEvent
   if (typeof navigator !== 'undefined') {
     isIE = navigator.userAgent.match(/Trident/) || navigator.userAgent.match(/Edge/)
-  }
-
-  requestFrame = (function () {
-    var raf = window.requestAnimationFrame ||
-      window.mozRequestAnimationFrame ||
-        window.webkitRequestAnimationFrame ||
-          function fallbackRAF(func) {
-            return window.setTimeout(func, 20)
-          }
-    return function requestFrameFunction(func) {
-      return raf(func)
-    }
-  })()
-
-  var cancelFrame = (function () {
-    var cancel = window.cancelAnimationFrame ||
-      window.mozCancelAnimationFrame ||
-        window.webkitCancelAnimationFrame ||
-          window.clearTimeout
-    return function cancelFrameFunction(id) {
-      return cancel(id)
-    }
-  })()
-
-  function resizeListener(e) {
-    var win = e.target || e.srcElement
-    if (win.__resizeRAF__) {
-      cancelFrame(win.__resizeRAF__)
-    }
-    win.__resizeRAF__ = requestFrame(function () {
-      var trigger = win.__resizeTrigger__
-      trigger.__resizeListeners__.forEach(function (fn) {
-        fn.call(trigger, e)
-      })
-    })
   }
 
   function objectLoad() {
@@ -76,17 +75,21 @@ var exports = function exports(element, fn) {
   element.__resizeListeners__.push(fn)
 }
 
-exports.unbind = function(element, fn){
-  var attachEvent = document.attachEvent;
-  element.__resizeListeners__.splice(element.__resizeListeners__.indexOf(fn), 1);
+module.exports = (typeof window === 'undefined') ? exports : exports.bind(window)
+
+module.exports.unbind = function(element, fn){
+  var attachEvent = document.attachEvent
+  if (fn) {
+    element.__resizeListeners__.splice(element.__resizeListeners__.indexOf(fn), 1)
+  } else {
+    element.__resizeListeners__ = []
+  }
   if (!element.__resizeListeners__.length) {
     if (attachEvent) {
-      element.detachEvent('onresize', resizeListener);
+      element.detachEvent('onresize', resizeListener)
     } else {
-      element.__resizeTrigger__.contentDocument.defaultView.removeEventListener('resize', resizeListener);
-      element.__resizeTrigger__ = !element.removeChild(element.__resizeTrigger__);
+      element.__resizeTrigger__.contentDocument.defaultView.removeEventListener('resize', resizeListener)
+      element.__resizeTrigger__ = !element.removeChild(element.__resizeTrigger__)
     }
   }
 }
-
-module.exports = (typeof window === 'undefined') ? exports : exports.bind(window)

--- a/index.js
+++ b/index.js
@@ -89,7 +89,9 @@ module.exports.unbind = function(element, fn){
       element.detachEvent('onresize', resizeListener)
     } else {
       element.__resizeTrigger__.contentDocument.defaultView.removeEventListener('resize', resizeListener)
+      delete element.__resizeTrigger__.contentDocument.defaultView.__resizeTrigger__
       element.__resizeTrigger__ = !element.removeChild(element.__resizeTrigger__)
     }
+    delete element.__resizeListeners__
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "element-resize-event",
   "description": "Polyfill to make it easy to listen for element resize events",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "bugs": {
     "url": "https://github.com/KyleAMathews/element-resize-event/issues"


### PR DESCRIPTION
So I evidently didn't notice that 'exports' was being redefined at the bottom of the file when 'window' existed. oops

Moving the unbind definition to after that point makes it be properly exported.