### PR TITLE
Add unbind usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,9 @@ Code borrowed from a [blog post by
 backalleycoder.com](http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection/).
 
 ## Install
-
 `npm install element-resize-event`
 
 ## Usage
-
 ```javascript
 var elementResizeEvent = require('element-resize-event');
 
@@ -24,7 +22,6 @@ elementResizeEvent(element, function() {
 ```
 
 ### Unbinding The Event Listener
-
 ```javascript
 var unbind = require('element-resize-event').unbind;
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ Code borrowed from a [blog post by
 backalleycoder.com](http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection/).
 
 ## Install
+
 `npm install element-resize-event`
 
 ## Usage
+
 ```javascript
 var elementResizeEvent = require('element-resize-event');
 
@@ -19,4 +21,12 @@ elementResizeEvent(element, function() {
   console.log("resized!");
   console.log(element.offsetWidth);
 });
+```
+
+### Unbinding The Event Listener
+
+```javascript
+var unbind = require('element-resize-event').unbind;
+
+unbind(element);
 ```


### PR DESCRIPTION
I was getting errors and realized the event needed to be unbound when an element will be removed from the DOM; after digging through a couple issues and the source code I figured out how to use `unbind` and thought it would be good to have an example in the README.