### PR TITLE
Giving CSS declaration more priority to ensure it always work

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ var exports = function exports(element, fn) {
       var obj = (element.__resizeTrigger__ = document.createElement('object'))
       obj.setAttribute(
         'style',
-        'display: block; position: absolute; top: 0; left: 0; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1; opacity: 0;'
+        'display: block !important; position: absolute !important; top: 0 !important; left: 0 !important; height: 100% !important; width: 100% !important; overflow: hidden !important; pointer-events: none !important; z-index: -1 !important; opacity: 0 !important;'
       )
       obj.setAttribute('class', 'resize-sensor')
       obj.__resizeElement__ = element

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ var exports = function exports(element, fn) {
       element.attachEvent('onresize', resizeListener)
     } else {
       if (getComputedStyle(element).position === 'static') {
-        element.style.position = 'relative'
+        element.style.setProperty('position', 'relative', 'important')
       }
       var obj = (element.__resizeTrigger__ = document.createElement('object'))
       obj.setAttribute(


### PR DESCRIPTION
I encounter a bug when making a third part widget. In this widget, I have to use [cleanslate](https://github.com/premasagar/cleanslate) to write more defensive CSS to protect my widget's style from been overwritten by the client's CSS. Take a CSS reset rule from cleanslate for example: 

```css
.cleanslate div {
    position:static !important;
}
```
This CSS rule will absolutly win  `element.style.position = 'relative'` in CSS specificity and break the way 'element-resize-event' works. So I made this pull request to fix this issue.

Love to hear your thought.