### PR TITLE
Remove polyfil

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ backalleycoder.com](http://www.backalleycoder.com/2013/03/18/cross-browser-event
 ## Install
 `npm install element-resize-event`
 
+## Dependencies
+This library depends on the availability of `requestAnimationFrame` and `cancelAnimationFrame`
+
 ## Usage
 ```javascript
 var elementResizeEvent = require('element-resize-event');

--- a/index.js
+++ b/index.js
@@ -1,33 +1,9 @@
-var requestFrame = (function () {
-  var window = this
-  var raf = window.requestAnimationFrame ||
-    window.mozRequestAnimationFrame ||
-    window.webkitRequestAnimationFrame ||
-    function fallbackRAF(func) {
-      return window.setTimeout(func, 20)
-    }
-  return function requestFrameFunction(func) {
-    return raf(func)
-  }
-})()
-
-var cancelFrame = (function () {
-  var window = this
-  var cancel = window.cancelAnimationFrame ||
-    window.mozCancelAnimationFrame ||
-    window.webkitCancelAnimationFrame ||
-    window.clearTimeout
-  return function cancelFrameFunction(id) {
-    return cancel(id)
-  }
-})()
-
 function resizeListener(e) {
   var win = e.target || e.srcElement
   if (win.__resizeRAF__) {
-    cancelFrame(win.__resizeRAF__)
+    cancelAnimationFrame(win.__resizeRAF__)
   }
-  win.__resizeRAF__ = requestFrame(function () {
+  win.__resizeRAF__ = requestAnimationFrame(function () {
     var trigger = win.__resizeTrigger__
     trigger.__resizeListeners__.forEach(function (fn) {
       fn.call(trigger, e)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "element-resize-event",
   "description": "Polyfill to make it easy to listen for element resize events",
-  "version": "2.0.8",
+  "version": "3.0.0",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "bugs": {
     "url": "https://github.com/KyleAMathews/element-resize-event/issues"


### PR DESCRIPTION
Fixes https://github.com/KyleAMathews/element-resize-event/issues/19

It should not be a dependencies responsibility to ship polyfils but the users. Otherwise we end up with x duplications for each dependency that decides to ship it. RAF is also [widely available](http://caniuse.com/#feat=requestanimationframe).