### PR TITLE
make sure that trigger exists before calling listeners on it

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function resizeListener(e) {
   }
   win.__resizeRAF__ = requestFrame(function () {
     var trigger = win.__resizeTrigger__
-    trigger.__resizeListeners__.forEach(function (fn) {
+    trigger && trigger.__resizeListeners__.forEach(function (fn) {
       fn.call(trigger, e)
     })
   })


### PR DESCRIPTION
Howdy. I have code that creates and removes elements very rapidly, so that when it's time for `requestAnimationFrame` original element was already deleted. All of my callbacks are accounting for that, but internally `requestFrame` crashes like that:
![image](https://user-images.githubusercontent.com/7026/27100548-64b00c0e-5033-11e7-807b-bebfaf5ddaf9.png)
and this simple check seem to be enough to fix the crash