### PR TITLE
Fix keyboard accessibility issue

### DIFF
--- a/example/bundle.js
+++ b/example/bundle.js
@@ -14,50 +14,52 @@ console.log(elementResizeEvent(element, function() {
 }));
 
 },{"../index.js":2}],2:[function(require,module,exports){
+var requestFrame = (function () {
+  var window = this
+  var raf = window.requestAnimationFrame ||
+    window.mozRequestAnimationFrame ||
+    window.webkitRequestAnimationFrame ||
+    function fallbackRAF(func) {
+      return window.setTimeout(func, 20)
+    }
+  return function requestFrameFunction(func) {
+    return raf(func)
+  }
+})()
+
+var cancelFrame = (function () {
+  var window = this
+  var cancel = window.cancelAnimationFrame ||
+    window.mozCancelAnimationFrame ||
+    window.webkitCancelAnimationFrame ||
+    window.clearTimeout
+  return function cancelFrameFunction(id) {
+    return cancel(id)
+  }
+})()
+
+function resizeListener(e) {
+  var win = e.target || e.srcElement
+  if (win.__resizeRAF__) {
+    cancelFrame(win.__resizeRAF__)
+  }
+  win.__resizeRAF__ = requestFrame(function () {
+    var trigger = win.__resizeTrigger__
+    trigger.__resizeListeners__.forEach(function (fn) {
+      fn.call(trigger, e)
+    })
+  })
+}
+
 var exports = function exports(element, fn) {
   var window = this
   var document = window.document
   var isIE
-  var requestFrame
 
   var attachEvent = document.attachEvent
   if (typeof navigator !== 'undefined') {
-    isIE = navigator.userAgent.match(/Trident/) || navigator.userAgent.match(/Edge/)
-  }
-
-  requestFrame = (function () {
-    var raf = window.requestAnimationFrame ||
-      window.mozRequestAnimationFrame ||
-        window.webkitRequestAnimationFrame ||
-          function fallbackRAF(func) {
-            return window.setTimeout(func, 20)
-          }
-    return function requestFrameFunction(func) {
-      return raf(func)
-    }
-  })()
-
-  var cancelFrame = (function () {
-    var cancel = window.cancelAnimationFrame ||
-      window.mozCancelAnimationFrame ||
-        window.webkitCancelAnimationFrame ||
-          window.clearTimeout
-    return function cancelFrameFunction(id) {
-      return cancel(id)
-    }
-  })()
-
-  function resizeListener(e) {
-    var win = e.target || e.srcElement
-    if (win.__resizeRAF__) {
-      cancelFrame(win.__resizeRAF__)
-    }
-    win.__resizeRAF__ = requestFrame(function () {
-      var trigger = win.__resizeTrigger__
-      trigger.__resizeListeners__.forEach(function (fn) {
-        fn.call(trigger, e)
-      })
-    })
+    isIE = navigator.userAgent.match(/Trident/) ||
+      navigator.userAgent.match(/Edge/)
   }
 
   function objectLoad() {
@@ -74,9 +76,16 @@ var exports = function exports(element, fn) {
       if (getComputedStyle(element).position === 'static') {
         element.style.position = 'relative'
       }
-      var obj = element.__resizeTrigger__ = document.createElement('object')
-      obj.setAttribute('style', 'display: block; position: absolute; top: 0; left: 0; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1;')
+      var obj = (element.__resizeTrigger__ = document.createElement('object'))
+      obj.setAttribute(
+        'style',
+        'display: block; position: absolute; top: 0; left: 0; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1; opacity: 0;'
+      )
       obj.setAttribute('class', 'resize-sensor')
+
+      // prevent <object> from stealing keyboard focus
+      obj.setAttribute('tabindex', '-1');
+
       obj.__resizeElement__ = element
       obj.onload = objectLoad
       obj.type = 'text/html'
@@ -92,12 +101,15 @@ var exports = function exports(element, fn) {
   element.__resizeListeners__.push(fn)
 }
 
-module.exports = (typeof window === 'undefined') ? exports : exports.bind(window)
+module.exports = typeof window === 'undefined' ? exports : exports.bind(window)
 
-module.exports.unbind = function(element, fn){
+module.exports.unbind = function (element, fn) {
   var attachEvent = document.attachEvent
   if (fn) {
-    element.__resizeListeners__.splice(element.__resizeListeners__.indexOf(fn), 1)
+    element.__resizeListeners__.splice(
+      element.__resizeListeners__.indexOf(fn),
+      1
+    )
   } else {
     element.__resizeListeners__ = []
   }
@@ -105,9 +117,16 @@ module.exports.unbind = function(element, fn){
     if (attachEvent) {
       element.detachEvent('onresize', resizeListener)
     } else {
-      element.__resizeTrigger__.contentDocument.defaultView.removeEventListener('resize', resizeListener)
-      element.__resizeTrigger__ = !element.removeChild(element.__resizeTrigger__)
+      element.__resizeTrigger__.contentDocument.defaultView.removeEventListener(
+        'resize',
+        resizeListener
+      )
+      delete element.__resizeTrigger__.contentDocument.defaultView.__resizeTrigger__
+      element.__resizeTrigger__ = !element.removeChild(
+        element.__resizeTrigger__
+      )
     }
+    delete element.__resizeListeners__
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
         <p id="width">100px wide</p>
         <p style="resize:both;width:100px;overflow:scroll;border:1px solid black;" id="resize">You can resize me!</p>
 
+        <textarea>You can focus me!</textarea>
+
         <script src="example/bundle.js"></script>
     </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -66,6 +66,10 @@ var exports = function exports(element, fn) {
         'display: block; position: absolute; top: 0; left: 0; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1; opacity: 0;'
       )
       obj.setAttribute('class', 'resize-sensor')
+
+      // prevent <object> from stealing keyboard focus
+      obj.setAttribute('tabindex', '-1');
+
       obj.__resizeElement__ = element
       obj.onload = objectLoad
       obj.type = 'text/html'


### PR DESCRIPTION
When using this module, the `<object>` it creates for the `resize-sensor` will "steal" keyboard focus, preventing the user from navigating through the page.

I've added a `textarea` element to the example to show the defect. Before the change, when trying to tab in to the page, keyboard focus will never reach the textarea. After the fix, keyboard focus reaches it, as the `tabindex: -1` property prevents the `<object>` from being focusable.

Since the example rebuild changed a bit of the bundle.js file, I included it in a separate commit. 