### PR TITLE
Fix for undefined resizeTriggers

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,9 +29,11 @@ function resizeListener(e) {
   }
   win.__resizeRAF__ = requestFrame(function () {
     var trigger = win.__resizeTrigger__
-    trigger.__resizeListeners__.forEach(function (fn) {
-      fn.call(trigger, e)
-    })
+    if(trigger !== undefined){
+      trigger.__resizeListeners__.forEach(function (fn) {
+        fn.call(trigger, e)
+      })
+    }
   })
 }
 


### PR DESCRIPTION
I would get errors with react-sticky-table when resizing the window while the content was rendered. The event inside the resizeListener would have no target, therefore crashing at this point.