### PR TITLE
Avoid using keyword exports as identifier

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function resizeListener(e) {
   })
 }
 
-var _exports = function exports(element, fn) {
+var _exports = function(element, fn) {
   var window = this
   var document = window.document
   var isIE


### PR DESCRIPTION
Terser and tools that use Terser might be failing when trying to optimize `function exports`. See https://github.com/parcel-bundler/parcel/issues/7090